### PR TITLE
.NET Unit test fix and Nuget fix

### DIFF
--- a/src/.net/Splinter.NanoInstances.Default.Tests/ServicesTests/ContainerTests/TeraAgentContainerTests.cs
+++ b/src/.net/Splinter.NanoInstances.Default.Tests/ServicesTests/ContainerTests/TeraAgentContainerTests.cs
@@ -44,7 +44,7 @@ public class TeraAgentContainerTests
             await container.Register(agent);
         }
 
-        Thread.Sleep(1000);
+        Thread.Sleep(5000);
 
         Assert.AreEqual(DefaultNumberOfTestAgents, container.NumberOfTeraAgents);
         Assert.AreEqual(DefaultNumberOfTestAgents, TeraAgentContainerUnitTestAgent.ExecutionHit);

--- a/src/azure-pipelines.yml
+++ b/src/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
       command: pack
       packagesToPack: '$(nanoTypesNugetProject)'
       packDestination: '$(Build.ArtifactStagingDirectory)'
-      noBuild: true
+      noBuild: false
       includeSymbols: true
       versioningScheme: byEnvVar
       versionEnvVar: 'versionNumber'
@@ -88,7 +88,7 @@ jobs:
       command: pack
       packagesToPack: '$(nanoInstancesNugetProject)'
       packDestination: '$(Build.ArtifactStagingDirectory)'
-      noBuild: true
+      noBuild: false
       includeSymbols: true
       versioningScheme: byEnvVar
       versionEnvVar: 'versionNumber'      


### PR DESCRIPTION
20220704 - Added unit test fix that runs slower on Azure devops
20220704 - Removed the --no-build target for the Dotnet Nuget packages.